### PR TITLE
Make more bats spawn in bat waves

### DIFF
--- a/main/binheap.lua
+++ b/main/binheap.lua
@@ -1,0 +1,60 @@
+-- Binary Heap implementation copy-pasted from https://gist.github.com/starwing/1757443a1bd295653c39
+-- BinaryHeap[1] always points to the element with the lowest "key" variable
+-- API
+-- BinaryHeap(key) - Creates a new BinaryHeap with key. The key is the name of the integer variable used to sort objects.
+-- BinaryHeap:Insert - Inserts an object into BinaryHeap
+-- BinaryHeap:Remove - Removes an object from BinaryHeap
+
+BinaryHeap = BinaryHeap or {}
+BinaryHeap.__index = BinaryHeap
+
+function BinaryHeap:Insert(item)
+	local index = #self + 1
+	local key = self.key
+	item.index = index
+	self[index] = item
+	while index > 1 do
+		local parent = math.floor(index/2)
+		if self[parent][key] <= item[key] then
+			break
+		end
+		self[index], self[parent] = self[parent], self[index]
+		self[index].index = index
+		self[parent].index = parent
+		index = parent
+	end
+	return item
+end
+
+function BinaryHeap:Remove(item)
+	local index = item.index
+	if self[index] ~= item then return end
+	local key = self.key
+	local heap_size = #self
+	if index == heap_size then
+		self[heap_size] = nil
+		return
+	end
+	self[index] = self[heap_size]
+	self[index].index = index
+	self[heap_size] = nil
+	while true do
+		local left = index*2
+		local right = left + 1
+		if not self[left] then break end
+		local newindex = right
+		if self[index][key] >= self[left][key] then
+			if not self[right] or self[left][key] < self[right][key] then
+				newindex = left
+			end
+		elseif not self[right] or self[index][key] <= self[right][key] then
+			break
+		end
+		self[index], self[newindex] = self[newindex], self[index]
+		self[index].index = index
+		self[newindex].index = newindex
+		index = newindex
+	end
+end
+
+setmetatable(BinaryHeap, {__call = function(self, key) return setmetatable({key=key}, self) end})

--- a/main/binheap.lua
+++ b/main/binheap.lua
@@ -13,7 +13,8 @@ BinaryHeap.__index = BinaryHeap
 function BinaryHeap:Insert(item)
 	local index = #self + 1
 	local key = self.key
-	item.index = index
+	local indexkey = self.indexkey
+	item[indexkey] = index
 	self[index] = item
 	while index > 1 do
 		local parent = math.floor(index/2)
@@ -21,15 +22,16 @@ function BinaryHeap:Insert(item)
 			break
 		end
 		self[index], self[parent] = self[parent], self[index]
-		self[index].index = index
-		self[parent].index = parent
+		self[index][indexkey] = index
+		self[parent][indexkey] = parent
 		index = parent
 	end
 	return item
 end
 
 function BinaryHeap:Remove(item)
-	local index = item.index
+	local indexkey = self.indexkey
+	local index = item[indexkey]
 	if self[index] ~= item then return end
 	local key = self.key
 	local heap_size = #self
@@ -38,7 +40,7 @@ function BinaryHeap:Remove(item)
 		return
 	end
 	self[index] = self[heap_size]
-	self[index].index = index
+	self[index][indexkey] = index
 	self[heap_size] = nil
 	while true do
 		local left = index*2
@@ -53,10 +55,10 @@ function BinaryHeap:Remove(item)
 			break
 		end
 		self[index], self[newindex] = self[newindex], self[index]
-		self[index].index = index
-		self[newindex].index = newindex
+		self[index][indexkey] = index
+		self[newindex][indexkey] = newindex
 		index = newindex
 	end
 end
 
-setmetatable(BinaryHeap, {__call = function(self, key) return setmetatable({key=key}, self) end})
+setmetatable(BinaryHeap, {__call = function(self, key, indexkey) return setmetatable({key=key, indexkey = indexkey}, self) end})

--- a/main/binheap.lua
+++ b/main/binheap.lua
@@ -7,7 +7,7 @@
 
 GLOBAL.setfenv(1, GLOBAL)
 
-BinaryHeap = BinaryHeap or {}
+BinaryHeap = {}
 BinaryHeap.__index = BinaryHeap
 
 function BinaryHeap:Insert(item)

--- a/main/binheap.lua
+++ b/main/binheap.lua
@@ -5,6 +5,8 @@
 -- BinaryHeap:Insert - Inserts an object into BinaryHeap
 -- BinaryHeap:Remove - Removes an object from BinaryHeap
 
+GLOBAL.setfenv(1, GLOBAL)
+
 BinaryHeap = BinaryHeap or {}
 BinaryHeap.__index = BinaryHeap
 

--- a/main/binheap.lua
+++ b/main/binheap.lua
@@ -1,7 +1,7 @@
 -- Binary Heap implementation copy-pasted from https://gist.github.com/starwing/1757443a1bd295653c39
 -- BinaryHeap[1] always points to the element with the lowest "key" variable
 -- API
--- BinaryHeap(key) - Creates a new BinaryHeap with key. The key is the name of the integer variable used to sort objects.
+-- BinaryHeap(key, indexkey) - Creates a new BinaryHeap with key. Index in the binary heap is stored in item[indexkey]. The key is the name of the integer variable used to sort objects.
 -- BinaryHeap:Insert - Inserts an object into BinaryHeap
 -- BinaryHeap:Remove - Removes an object from BinaryHeap
 

--- a/modmain.lua
+++ b/modmain.lua
@@ -7,6 +7,7 @@ PL_CONFIG = {
 
 modimport("main/constants")
 modimport("main/util")
+modimport("main/binheap")
 -- modimport("main/oceanutil")
 
 modimport("main/assets")

--- a/postinit/prefabs/player.lua
+++ b/postinit/prefabs/player.lua
@@ -96,6 +96,11 @@ local function OnLoad(inst, data, ...)
         if data.is_ghost then
             --blockPoison(inst)
         end
+        
+        if data.porkland_nextbattedtime then
+            local current_time = TheWorld.state.cycles + TheWorld.state.time
+            inst.porkland_nextbattedtime = data.porkland_nextbattedtime + current_time --add here to prevent instant bat upon load
+        end
     end
     -- Well this really sucks, thanks for making my life hell klei :) (I blame Zarklord specifically because funi)
     local _DoTaskInTime = inst.DoTaskInTime
@@ -114,9 +119,18 @@ local function OnLoad(inst, data, ...)
             return unpack(_rets)
         end or nil, ...)
     end
+    
     local rets = {inst.__OnLoad(inst, data, ...)}
     inst.DoTaskInTime = _DoTaskInTime
     return unpack(rets)
+end
+
+local function OnSave(inst, data, ...)
+    if inst.porkland_nextbattedtime then
+        local current_time = TheWorld.state.cycles + TheWorld.state.time
+        data.porkland_nextbattedtime = inst.porkland_nextbattedtime - current_time --add here to prevent instant bat upon load
+    end
+    inst.__OnSave(inst, data, ...)
 end
 
 local function UpdateHomeTechBonus(inst, data)
@@ -224,6 +238,11 @@ AddPlayerPostInit(function(inst)
     if inst.OnLoad then
         inst.__OnLoad = inst.OnLoad
         inst.OnLoad = OnLoad
+    end
+
+    if inst.OnSave then
+        inst.__OnSave = inst.OnSave
+        inst.OnSave = OnSave
     end
 
 end)

--- a/postinit/prefabs/player.lua
+++ b/postinit/prefabs/player.lua
@@ -99,7 +99,7 @@ local function OnLoad(inst, data, ...)
         
         if data.porkland_nextbattedtime then
             local current_time = TheWorld.state.cycles + TheWorld.state.time
-            inst.porkland_nextbattedtime = data.porkland_nextbattedtime + current_time --add here to prevent instant bat upon load
+            inst.porkland_nextbattedtime = data.porkland_nextbattedtime + current_time * TUNING.TOTAL_DAY_TIME - TheWorld.components.batted._player_battime_startindex --add here to prevent instant bat upon load
         end
     end
     -- Well this really sucks, thanks for making my life hell klei :) (I blame Zarklord specifically because funi)
@@ -128,7 +128,7 @@ end
 local function OnSave(inst, data, ...)
     if inst.porkland_nextbattedtime then
         local current_time = TheWorld.state.cycles + TheWorld.state.time
-        data.porkland_nextbattedtime = inst.porkland_nextbattedtime - current_time --add here to prevent instant bat upon load
+        data.porkland_nextbattedtime = inst.porkland_nextbattedtime - current_time * TUNING.TOTAL_DAY_TIME + TheWorld.components.batted._player_battime_startindex --add here to prevent instant bat upon load
     end
     inst.__OnSave(inst, data, ...)
 end

--- a/scripts/components/aporkalypse.lua
+++ b/scripts/components/aporkalypse.lua
@@ -322,7 +322,7 @@ return Class(function(self, inst)
                 end
 
                 local batted = _world.components.batted
-                batted:RegenBat(15)
+                batted:RegenBat(15 + 13 * (#AllPlayers - 1))
                 batted:ForceBatAttack()
                 ScheduleBatAttack()
             end

--- a/scripts/components/aporkalypse.lua
+++ b/scripts/components/aporkalypse.lua
@@ -322,7 +322,7 @@ return Class(function(self, inst)
                 end
 
                 local batted = _world.components.batted
-                batted:RegenBat(15 + 13 * (#AllPlayers - 1))
+                batted:RegenBat(15)
                 batted:ForceBatAttack()
                 ScheduleBatAttack()
             end

--- a/scripts/components/batted.lua
+++ b/scripts/components/batted.lua
@@ -96,21 +96,31 @@ local function AddBatToCaves()
     end
 end
 
-local function GetNextRegenTime()
-    local day = TheWorld.state.cycles
-    local time = 130
+local RATE_D5 = 1 / 960  -- 1 bat every 2 days
+local RATE_D10 = 1 / 720 -- 1 bat every 1.5 days
+local RATE_D20 = 1 / 480 -- 1 bat a day
+local RATE_D40 = 1 / 360 -- 1.5 bats / day
+local RATE_D40P = 1 / 240 -- 2 bats / day
 
-    if day < 5 then
-        time = 960 -- 1 bat every 2 days
-    elseif day < 10 then
-        time = 720 -- 1 bat every 1.5 days
-    elseif day < 20 then
-        time = 480 -- 1 bat a day
-    elseif day < 40 then
-        time = 360 -- 1.5 bats / day
-    else
-        time = 240 -- 2 bats / day
+local function GetNextRegenTime()
+    --local day = TheWorld.state.cycles
+    local time = 130
+    local rate = 0
+    for _, player in pairs(AllPlayers) do
+        local age = player.components.age:GetAgeInDays()     
+        if age < 5 then
+            rate = rate + RATE_D5
+        elseif age < 10 then
+            rate = rate + RATE_D10
+        elseif age < 20 then
+            rate = rate + RATE_D20
+        elseif age < 40 then
+            rate = rate + RATE_D40
+        else
+            rate = rate + RATE_D40P
+        end
     end
+    if rate ~= 0 then time = 1 / rate end
 
     return time * _time_modifiers:CalculateModifierFromKey(MODIFIER_KEY_REGEN_TIME)
 end

--- a/scripts/components/batted.lua
+++ b/scripts/components/batted.lua
@@ -46,7 +46,7 @@ local _bat_per_player = 0
 local _bat_remainder = 0
 local _time_modifiers = SourceModifierList(inst, 1)
 
-local _player_battime_binaryheap = BinaryHeap({}, "porkland_nextbattedtime")
+local _player_battime_binaryheap = BinaryHeap("porkland_nextbattedtime")
 local _target_player = nil
 
 --------------------------------------------------------------------------
@@ -429,7 +429,7 @@ function self:LongUpdate(dt)
                     _bat_attack_time = GetNextAttackTime() / 10 --we have more bat attacks, start sooner
                 else
                     local current_time = TheWorld.state.cycles + TheWorld.state.time
-                    _target_player.porkland_nextbattedtime = current_time + GetNextAttackTime()
+                    _target_player.porkland_nextbattedtime = current_time + GetNextAttackTime() / TUNING.TOTAL_DAY_TIME
                     _player_battime_binaryheap:Insert(_target_player)
                     _target_player = nil
                     _bat_attack_time = _player_battime_binaryheap[1].porkland_nextbattedtime - current_time
@@ -510,7 +510,7 @@ local function AddToHeap(src, player)
     player:DoTaskInTime(0, function()
         if not player.porkland_nextbattedtime then --new player or just joined ham
             local current_time = TheWorld.state.cycles + TheWorld.state.time
-            player.porkland_nextbattedtime = current_time + GetNextAttackTime()
+            player.porkland_nextbattedtime = current_time + GetNextAttackTime() / TUNING.TOTAL_DAY_TIME
         end
 		print("BATTED_TIME", player, player.porkland_nextbattedtime)
         _player_battime_binaryheap:Insert(player)

--- a/scripts/components/batted.lua
+++ b/scripts/components/batted.lua
@@ -446,7 +446,7 @@ function self:LongUpdate(dt)
 				end
 				if _force_bat_mean and _force_bat_iters < #AllPlayers then
 					_force_bat_count = GetRandomWithVariance(_force_bat_mean, _force_bat_variance)
-					batted:RegenBat(_force_bat_count)
+					self:RegenBat(_force_bat_count)
 					_force_bat_iters = _force_bat_iters + 1
 				end
             end

--- a/scripts/components/batted.lua
+++ b/scripts/components/batted.lua
@@ -48,6 +48,8 @@ local _time_modifiers = SourceModifierList(inst, 1)
 
 local _player_battime_binaryheap = BinaryHeap("porkland_nextbattedtime", "porkland_nextbattedtime_index")
 local _target_player = nil
+local _force_bat_min = nil
+local _force_bat_max = nil
 
 --------------------------------------------------------------------------
 --[[ Private event handlers ]]
@@ -193,28 +195,33 @@ local function CollectBatsForAttack()
     local age = _target_player.components.age:GetAgeInDays()
     local min_bound = 0
     local max_bound = 0
-    if age < 10 then
-        min_bound = 2
-        max_bound = 2
-    elseif age < 25 then
-        min_bound = 3
-        max_bound = 4
-    elseif age < 50 then
-        min_bound = 4
-        max_bound = 6
-    elseif age < 100 then
-        min_bound = 5
-        max_bound = 7
-    else
-        min_bound = 7
-        max_bound = 50
-    end --bounds copied from dst wiki
+	if _force_bat_min then
+		min_bound = _force_bat_min
+		max_bound = _force_bat_max
+	else
+		if age < 10 then
+			min_bound = 2
+			max_bound = 2
+		elseif age < 25 then
+			min_bound = 3
+			max_bound = 4
+		elseif age < 50 then
+			min_bound = 4
+			max_bound = 6
+		elseif age < 100 then
+			min_bound = 5
+			max_bound = 7
+		else
+			min_bound = 7
+			max_bound = 50
+		end --bounds copied from dst wiki
+	end
 
     if suitable_bat_count < min_bound then
         _bat_per_player = 0 --force failure
         _player_battime_binaryheap:Insert(_target_player)
         _target_player = nil
-        print("bat attack cant find enough bats", min_bound, "is not less than", suitable_bat_count)
+        print("bat attack cant find enough bats", suitable_bat_count, "is less than", min_bound)
     elseif suitable_bat_count > max_bound then -- Throw everything on 1 player, the others have their own batted timer.
         _bat_per_player = max_bound
     else
@@ -436,6 +443,8 @@ function self:LongUpdate(dt)
 					_bat_attack_time = GetNextAttackTime() / player_mod
 				end
             end
+			_force_bat_min = nil
+			_force_bat_max = nil
         end
     end
 end
@@ -536,6 +545,8 @@ end
 
 function self:ForceBatAttack()
     _bat_attack_time = 0
+	_force_bat_min = 13
+	_force_bat_max = 15
     self:OnUpdate(0)
 end
 

--- a/scripts/components/batted.lua
+++ b/scripts/components/batted.lua
@@ -168,11 +168,11 @@ local function CollectBatsForAttack()
     
     while _player_battime_binaryheap[1] ~= nil do --take stuff out of heap, heap is always sorted at [1] position
         _target_player = _player_battime_binaryheap[1]
-        _player_battime_binaryheap:Remove(target_player)
-        if not target_player:GetIsInInterior() then
+        _player_battime_binaryheap:Remove(_target_player)
+        if not _target_player:GetIsInInterior() then
             break    
         end
-        table.insert(putbackin_players, target_player)
+        table.insert(putbackin_players, _target_player)
     end
     
     for _, player in ipairs(putbackin_players) do
@@ -189,7 +189,7 @@ local function CollectBatsForAttack()
         end
     end
 
-    local age = target_player.components.age:GetAgeInDays()
+    local age = _target_player.components.age:GetAgeInDays()
     local min_bound = 0
     local max_bound = 0
     if age < 10 then

--- a/scripts/components/batted.lua
+++ b/scripts/components/batted.lua
@@ -506,16 +506,17 @@ end
 --[[ Binary Heap Detection ]]
 --------------------------------------------------------------------------
 
-local function AddToHeap(player)
+local function AddToHeap(src, player)
     player:DoTaskInTime(0, function()
         if not player.porkland_nextbattedtime then --new player or just joined ham
             local current_time = TheWorld.state.cycles + TheWorld.state.time
             player.porkland_nextbattedtime = current_time + GetNextAttackTime()
         end
+		print("BATTED_TIME", player, player.porkland_nextbattedtime)
         _player_battime_binaryheap:Insert(player)
     end)
 end
-local function RemoveFromHeap(player)
+local function RemoveFromHeap(src, player)
     _player_battime_binaryheap:Remove(player)
 end
         

--- a/scripts/components/batted.lua
+++ b/scripts/components/batted.lua
@@ -224,6 +224,7 @@ local function CollectBatsForAttack()
         _player_battime_binaryheap:Insert(_target_player)
         _target_player = nil
         print("bat attack cant find enough bats", suitable_bat_count, "is less than", min_bound)
+		return
     elseif suitable_bat_count > max_bound then -- Throw everything on 1 player, the others have their own batted timer.
         _bat_per_player = max_bound
     else
@@ -444,7 +445,7 @@ function self:LongUpdate(dt)
 					if player_mod == 0 then player_mod = 1 end
 					_bat_attack_time = GetNextAttackTime() / player_mod
 				end
-				if _force_bat_mean and _force_bat_iters < #AllPlayers then
+				if _force_bat_mean and _force_bat_iters < #AllPlayers - 1 then
 					_force_bat_count = GetRandomWithVariance(_force_bat_mean, _force_bat_variance)
 					self:RegenBat(_force_bat_count)
 					_force_bat_iters = _force_bat_iters + 1

--- a/scripts/components/batted.lua
+++ b/scripts/components/batted.lua
@@ -45,6 +45,8 @@ local _bat_per_player = 0
 local _bat_remainder = 0
 local _time_modifiers = SourceModifierList(inst, 1)
 
+local _player_battime_binaryheap = BinaryHeap({}, "porkland_nextbattedtime")
+
 --------------------------------------------------------------------------
 --[[ Private event handlers ]]
 --------------------------------------------------------------------------

--- a/scripts/components/batted.lua
+++ b/scripts/components/batted.lua
@@ -429,7 +429,7 @@ function self:LongUpdate(dt)
                     _bat_attack_time = GetNextAttackTime() / 10 --we have more bat attacks, start sooner
                 else
                     local current_time = TheWorld.state.cycles + TheWorld.state.time
-                    _target_player.porkland_nextbattedtime = current_time + GetNextAttackTime() / TUNING.TOTAL_DAY_TIME
+                    _target_player.porkland_nextbattedtime = current_time * TOTAL_DAY_TIME + GetNextAttackTime()
                     _player_battime_binaryheap:Insert(_target_player)
                     _target_player = nil
                     _bat_attack_time = _player_battime_binaryheap[1].porkland_nextbattedtime - current_time
@@ -510,7 +510,7 @@ local function AddToHeap(src, player)
     player:DoTaskInTime(0, function()
         if not player.porkland_nextbattedtime then --new player or just joined ham
             local current_time = TheWorld.state.cycles + TheWorld.state.time
-            player.porkland_nextbattedtime = current_time + GetNextAttackTime() / TUNING.TOTAL_DAY_TIME
+            player.porkland_nextbattedtime = current_time * TOTAL_DAY_TIME + GetNextAttackTime()
         end
 		print("BATTED_TIME", player, player.porkland_nextbattedtime)
         _player_battime_binaryheap:Insert(player)

--- a/scripts/components/batted.lua
+++ b/scripts/components/batted.lua
@@ -24,6 +24,7 @@ local MODIFIER_KEY_REGEN_TIME = "regen"
 local MODIFIER_RARE = 1.25
 local MODIFIER_OFTEN = 0.9
 local MODIFIER_ALWAYS = 0.75
+local _world = TheWorld
 
 --------------------------------------------------------------------------
 --[[ Member variables ]]
@@ -500,6 +501,20 @@ function self:LoadPostPass(ents, data)
         end
     end
 end
+
+--------------------------------------------------------------------------
+--[[ Binary Heap Detection ]]
+--------------------------------------------------------------------------
+
+local function AddToHeap(player)
+    _player_battime_binaryheap:Insert(player)
+end
+local function RemoveFromHeap(player)
+    _player_battime_binaryheap:Remove(player)
+end
+        
+inst:ListenForEvent("ms_playerspawn", AddToHeap, _world)
+inst:ListenForEvent("playerexited", AddToHeap, _world)
 
 --------------------------------------------------------------------------
 --[[ Debug ]]

--- a/scripts/components/batted.lua
+++ b/scripts/components/batted.lua
@@ -46,6 +46,7 @@ local _bat_remainder = 0
 local _time_modifiers = SourceModifierList(inst, 1)
 
 local _player_battime_binaryheap = BinaryHeap({}, "porkland_nextbattedtime")
+local _target_player = nil
 
 --------------------------------------------------------------------------
 --[[ Private event handlers ]]
@@ -161,14 +162,23 @@ local function IsBatSuitableForAttack(bat)
 end
 
 local function CollectBatsForAttack()
-    target_players = {}
-
-    for _, player in pairs(AllPlayers) do
-        if not player:GetIsInInterior() then
-            table.insert(target_players, player)
+    local putbackin_players = {}
+    _target_player = nil
+    
+    while _player_battime_binaryheap[1] ~= nil do --take stuff out of heap, heap is always sorted at [1] position
+        _target_player = _player_battime_binaryheap[1]
+        _player_battime_binaryheap:Remove(target_player)
+        if not target_player:GetIsInInterior() then
+            break    
         end
+        table.insert(putbackin_players, target_player)
     end
-    shuffleArray(target_players)
+    
+    for _, player in ipairs(putbackin_players) do
+        _player_battime_binaryheap:Insert(player)
+    end
+
+    if _target_player = nil then return end --no players
 
     local suitable_bat_count = 0
     for _, bat in pairs(_bats) do
@@ -178,11 +188,31 @@ local function CollectBatsForAttack()
         end
     end
 
+    local age = target_player.components.age:GetAgeInDays()
+    local min_bound = 0
+    local max_bound = 0
+    if age < 10 then
+        min_bound = 2
+        max_bound = 2
+    elseif age < 25 then
+        min_bound = 3
+        max_bound = 4
+    elseif age < 50 then
+        min_bound = 4
+        max_bound = 6
+    elseif age < 100 then
+        min_bound = 5
+        max_bound = 7
+    else
+        min_bound = 7
+        max_bound = 50
+    end --labels copied from dst wiki
+    
     -- Equally split among all players, each player gets at least 1 bat,
     -- if there are less bats than players, some players will not be attacked
     _bat_per_player = suitable_bat_count / math.max(GetTableSize(target_players), 1)
     _bat_remainder = suitable_bat_count % math.max(GetTableSize(target_players), 1)
-
+    
     print("_bat_per_player", _bat_per_player, suitable_bat_count)
 end
 

--- a/scripts/components/batted.lua
+++ b/scripts/components/batted.lua
@@ -410,28 +410,29 @@ function self:LongUpdate(dt)
             dt_bat_attack = 0
         else
             dt_bat_attack = dt_bat_attack - _bat_attack_time
-            CollectBatsForAttack()
             local spawnfailed = false
-
-            if next(_bats_to_attack) then
-                local no_bat_left
-                if _target_player then
-                    SpawnBatsForPlayer(_target_player)
-                else
-                    spawnfailed = true
-                    print("bat attack cant find any available player")
+            while not spawnfailed do --throw bats at players until spawn fails
+                CollectBatsForAttack()
+                if next(_bats_to_attack) then
+                    local no_bat_left
+                    if _target_player then
+                        SpawnBatsForPlayer(_target_player)
+                    else
+                        spawnfailed = true
+                        print("bat attack cant find any available player")
+                    end
+                    _bats_to_attack = {} -- reset it since all bats were removed
                 end
-                _bats_to_attack = {} -- reset it since all bats were removed
-            end
-
-            if spawnfailed then
-                _bat_attack_time = GetNextAttackTime() / 10 --we have more bat attacks, start sooner
-            else
-                local current_time = TheWorld.state.cycles + TheWorld.state.time
-                _target_player.porkland_nextbattedtime = current_time + GetNextAttackTime()
-                _player_battime_binaryheap:Insert(_target_player)
-                _target_player = nil
-                _bat_attack_time = _player_battime_binaryheap[1].porkland_nextbattedtime - current_time
+    
+                if spawnfailed then
+                    _bat_attack_time = GetNextAttackTime() / 10 --we have more bat attacks, start sooner
+                else
+                    local current_time = TheWorld.state.cycles + TheWorld.state.time
+                    _target_player.porkland_nextbattedtime = current_time + GetNextAttackTime()
+                    _player_battime_binaryheap:Insert(_target_player)
+                    _target_player = nil
+                    _bat_attack_time = _player_battime_binaryheap[1].porkland_nextbattedtime - current_time
+                end
             end
         end
     end

--- a/scripts/components/batted.lua
+++ b/scripts/components/batted.lua
@@ -445,7 +445,7 @@ function self:LongUpdate(dt)
 					_bat_attack_time = GetNextAttackTime() / player_mod
 				end
 				if _force_bat_mean and _force_bat_iters < #AllPlayers then
-					_force_bat_count = GetRandomWithVariance(_force_bat_mean + _force_bat_variance)
+					_force_bat_count = GetRandomWithVariance(_force_bat_mean, _force_bat_variance)
 					batted:RegenBat(_force_bat_count)
 					_force_bat_iters = _force_bat_iters + 1
 				end

--- a/scripts/components/batted.lua
+++ b/scripts/components/batted.lua
@@ -507,14 +507,20 @@ end
 --------------------------------------------------------------------------
 
 local function AddToHeap(player)
-    _player_battime_binaryheap:Insert(player)
+    player:DoTaskInTime(0, function()
+        if not player.porkland_nextbattedtime then --new player or just joined ham
+            local current_time = TheWorld.state.cycles + TheWorld.state.time
+            player.porkland_nextbattedtime = current_time + GetNextAttackTime()
+        end
+        _player_battime_binaryheap:Insert(player)
+    end)
 end
 local function RemoveFromHeap(player)
     _player_battime_binaryheap:Remove(player)
 end
         
 inst:ListenForEvent("ms_playerspawn", AddToHeap, _world)
-inst:ListenForEvent("playerexited", AddToHeap, _world)
+inst:ListenForEvent("ms_playerleft", RemoveFromHeap, _world)
 
 --------------------------------------------------------------------------
 --[[ Debug ]]

--- a/scripts/components/batted.lua
+++ b/scripts/components/batted.lua
@@ -413,7 +413,7 @@ function self:LongUpdate(dt)
         else
             dt_bat_attack = dt_bat_attack - _bat_attack_time
             local spawnfailed = false
-            --while not spawnfailed do --throw bats at players until spawn fails
+            while not spawnfailed do --throw bats at players until spawn fails
                 CollectBatsForAttack()
 				if not _target_player then
 					spawnfailed = true 
@@ -431,9 +431,11 @@ function self:LongUpdate(dt)
 					_target_player.porkland_nextbattedtime = current_time * TUNING.TOTAL_DAY_TIME + GetNextAttackTime()
 					_player_battime_binaryheap:Insert(_target_player)
 					_target_player = nil
-					_bat_attack_time = _player_battime_binaryheap[1].porkland_nextbattedtime - current_time * TUNING.TOTAL_DAY_TIME
+					local player_mod = #AllPlayers
+					if player_mod == 0 then player_mod = 1 end
+					_bat_attack_time = GetNextAttackTime() / player_mod
 				end
-            --end
+            end
         end
     end
 end

--- a/scripts/components/batted.lua
+++ b/scripts/components/batted.lua
@@ -179,7 +179,7 @@ local function CollectBatsForAttack()
         _player_battime_binaryheap:Insert(player)
     end
 
-    if _target_player = nil then return end --no players
+    if _target_player == nil then return end --no players
 
     local suitable_bat_count = 0
     for _, bat in pairs(_bats) do


### PR DESCRIPTION
- Bat waves are now dependent upon player day count
- Bat respawn rate is now dependent on number of players
- To accommodate for these changes, bat waves are now staggered per-player. It will attempt to alternate between all players to distribute the bats fairly.