### PR TITLE
Improve the stability of upvalue related code

### DIFF
--- a/main/actions.lua
+++ b/main/actions.lua
@@ -69,7 +69,7 @@ end
 
 ----set up the action functions
 local _ValidToolWork = ToolUtil.GetUpvalue(ACTIONS.CHOP.validfn, "ValidToolWork")
-local _DoToolWork, do_tool_work_up_index = ToolUtil.GetUpvalue(ACTIONS.CHOP.fn, "DoToolWork")
+local _DoToolWork, scope_fn, do_tool_work_up_index = ToolUtil.GetUpvalue(ACTIONS.CHOP.fn, "DoToolWork")
 local function DoToolWork(act, workaction, ...)
     if act.doer and act.doer.player_classified then
         act.doer.player_classified._last_work_target:set(act.target)
@@ -99,7 +99,7 @@ local function DoToolWork(act, workaction, ...)
     end
     return _DoToolWork(act, workaction, ...)
 end
-debug.setupvalue(ACTIONS.CHOP.fn, do_tool_work_up_index, DoToolWork)
+debug.setupvalue(scope_fn, do_tool_work_up_index, DoToolWork)
 
 ACTIONS.HACK.fn = function(act)
     DoToolWork(act, ACTIONS.HACK)
@@ -1257,7 +1257,7 @@ function PlayerController:DoActionAutoEquip(buffaction, ...)
 end
 
 function PLENV.OnHotReload()
-    debug.setupvalue(ACTIONS.CHOP.fn, do_tool_work_up_index, DoToolWork)
+    debug.setupvalue(scope_fn, do_tool_work_up_index, DoToolWork)
 
     ACTIONS.FERTILIZE.fn = _FERTILIZE_fn
     ACTIONS.EQUIP.fn = _EQUIP_fn

--- a/main/actions.lua
+++ b/main/actions.lua
@@ -69,7 +69,7 @@ end
 
 ----set up the action functions
 local _ValidToolWork = ToolUtil.GetUpvalue(ACTIONS.CHOP.validfn, "ValidToolWork")
-local _DoToolWork = ToolUtil.GetUpvalue(ACTIONS.CHOP.fn, "DoToolWork")
+local _DoToolWork, do_tool_work_up_index = ToolUtil.GetUpvalue(ACTIONS.CHOP.fn, "DoToolWork")
 local function DoToolWork(act, workaction, ...)
     if act.doer and act.doer.player_classified then
         act.doer.player_classified._last_work_target:set(act.target)
@@ -99,7 +99,7 @@ local function DoToolWork(act, workaction, ...)
     end
     return _DoToolWork(act, workaction, ...)
 end
-ToolUtil.SetUpvalue(ACTIONS.CHOP.fn, DoToolWork, "DoToolWork")
+debug.setupvalue(ACTIONS.CHOP.fn, do_tool_work_up_index, DoToolWork)
 
 ACTIONS.HACK.fn = function(act)
     DoToolWork(act, ACTIONS.HACK)
@@ -1257,7 +1257,7 @@ function PlayerController:DoActionAutoEquip(buffaction, ...)
 end
 
 function PLENV.OnHotReload()
-    ToolUtil.SetUpvalue(ACTIONS.CHOP.fn, _DoToolWork, "DoToolWork")
+    debug.setupvalue(ACTIONS.CHOP.fn, do_tool_work_up_index, DoToolWork)
 
     ACTIONS.FERTILIZE.fn = _FERTILIZE_fn
     ACTIONS.EQUIP.fn = _EQUIP_fn

--- a/main/constants.lua
+++ b/main/constants.lua
@@ -95,3 +95,10 @@ NAUGHTY_VALUE["pigeon"] = 1
 NAUGHTY_VALUE["piko"] = 1
 
 MAX_PHYSICS_RADIUS = 5.2 -- the biggest lilypad
+
+-- Revert all pickup sounds back
+for k, v in pairs(PICKUPSOUNDS) do
+    if k ~= "NONE" then
+        PICKUPSOUNDS[k] = "dontstarve/HUD/collect_resource"
+    end
+end

--- a/main/postinit.lua
+++ b/main/postinit.lua
@@ -1,6 +1,52 @@
 local modimport = modimport
 GLOBAL.setfenv(1, GLOBAL)
 
+local post_init_functions = {}
+
+-- Runs a callback on the prefab gets registered,
+-- if the prefab is already registered, the callback will be called immediately
+--
+-- ## Examples:
+--
+-- ```lua
+-- AddPrefabRegisterPostInit(function(spoiled_food)
+--     local spoiled_food_constructor = spoiled_food.fn
+--     local food_OnIsRaining, i, food_mastersim_init = ToolUtil.GetUpvalue(spoiled_food_constructor, "food_mastersim_init.food_OnIsRaining")
+--     if not food_OnIsRaining then
+--         return
+--     end
+--     debug.setupvalue(food_mastersim_init, i, function(inst, israining, ...)
+--         if inst:GetIsInInterior() then
+--             inst.components.disappears:StopDisappear()
+--             return
+--         end
+--         return food_OnIsRaining(inst, israining, ...)
+--     end)
+-- end)
+-- ```
+function AddPrefabRegisterPostInit(prefab, post_init)
+    if Prefabs[prefab] then
+        post_init(Prefabs[prefab])
+        return
+    end
+    if not post_init_functions[prefab] then
+        post_init_functions[prefab] = {}
+    end
+    table.insert(post_init_functions[prefab], post_init)
+end
+
+local register_prefabs_impl = RegisterPrefabsImpl
+RegisterPrefabsImpl = function(prefab, ...)
+    local ret = { register_prefabs_impl(prefab, ...) }
+    local prefab_name = prefab.name
+    if post_init_functions[prefab_name] then
+        for _, post_init in ipairs(post_init_functions[prefab_name]) do
+            post_init(prefab)
+        end
+    end
+    return unpack(ret)
+end
+
 -- Update this list when adding files
 local behaviour_posts = {
     "chaseandattack",

--- a/main/postinit.lua
+++ b/main/postinit.lua
@@ -11,7 +11,7 @@ local post_init_functions = {}
 -- ```lua
 -- AddPrefabRegisterPostInit(function(spoiled_food)
 --     local spoiled_food_constructor = spoiled_food.fn
---     local food_OnIsRaining, i, food_mastersim_init = ToolUtil.GetUpvalue(spoiled_food_constructor, "food_mastersim_init.food_OnIsRaining")
+--     local food_OnIsRaining, food_mastersim_init, i = ToolUtil.GetUpvalue(spoiled_food_constructor, "food_mastersim_init.food_OnIsRaining")
 --     if not food_OnIsRaining then
 --         return
 --     end

--- a/main/toolutil.lua
+++ b/main/toolutil.lua
@@ -38,15 +38,24 @@ local function get_upvalue(fn, name)
     end
 end
 
+--- Returns the upvalue, the up index, and the scope function,
+---
+--- ## Examples:
+---
+--- ```lua
+--- local telestaff_constructor = Prefabs["telestaff"].fn
+--- local teleport_start, i, teleport_func = ToolUtil.GetUpvalue(telestaff_constructor, "teleport_func.teleport_start")
+--- debug.setupvalue(teleport_func, i, function(...) print("hooked") return teleport_start(...) end)
+--- ```
 ---@param fn function
 ---@param path string
 ---@return any, number, function
 function ToolUtil.GetUpvalue(fn, path)
     local value, prv, i = fn, nil, nil ---@type any, function | nil, number | nil
     for part in path:gmatch("[^%.]+") do
-        -- print(part)
-        prv = fn
+        prv = value
         value, i = get_upvalue(value, part)
+        if not value then break end
     end
     return value, i, prv
 end

--- a/main/toolutil.lua
+++ b/main/toolutil.lua
@@ -21,51 +21,78 @@ function debug.setupvalue(fn, ...)
 end
 ToolUtil.HideFn(debug.setupvalue, _debug_setupvalue)
 
---Tool designed by Rezecib.
----@param fn function
----@param name string
----@return any, number | nil
-local function get_upvalue(fn, name)
-    local i = 1
-    while true do
-        local value_name, value = debug.getupvalue(fn, i)
-        if value_name == name then
-            return value, i
-        elseif value_name == nil then
-            return
-        end
+-- `GetUpvalue` and `SetUpvalue` were modified base on the upvalue tool designed by Rezecib
+
+local function upvalue_iter(fn)
+    local i = 0
+    return function()
         i = i + 1
+        local value_name, value = debug.getupvalue(fn, i)
+        return value_name, value, i
     end
 end
 
---- Returns the upvalue, the up index, and the scope function,
+-- Find the upvalue by comparing the names through all upvalues,
+-- returns the value and the up index
+local function find_upvalue(fn, name)
+    for value_name, value, index in upvalue_iter(fn) do
+        if value_name == name then
+            return value, index
+        end
+    end
+end
+
+local MAX_UPVALUE_SEARCH_DEPTH = 3
+
+--- Returns the upvalue, the up index, and the scope function
 ---
 --- ## Examples:
 ---
 --- ```lua
 --- local telestaff_constructor = Prefabs["telestaff"].fn
---- local teleport_start, i, teleport_func = ToolUtil.GetUpvalue(telestaff_constructor, "teleport_func.teleport_start")
+--- local teleport_start, teleport_func, i = ToolUtil.GetUpvalue(telestaff_constructor, "teleport_func.teleport_start")
 --- debug.setupvalue(teleport_func, i, function(...) print("hooked") return teleport_start(...) end)
 --- ```
 ---@param fn function
 ---@param path string
 ---@return any, number, function
-function ToolUtil.GetUpvalue(fn, path)
-    local value, prv, i = fn, nil, nil ---@type any, function | nil, number | nil
-    for part in path:gmatch("[^%.]+") do
-        prv = value
-        value, i = get_upvalue(value, part)
-        if not value then break end
+function ToolUtil.GetUpvalue(fn, path, depth)
+    if not depth then
+        depth = 1
     end
-    return value, i, prv
+
+    local value, scope_fn, index = fn, nil, nil ---@type any, function | nil, number | nil
+
+    for part in path:gmatch("[^%.]+") do
+        scope_fn = value
+        value, index = find_upvalue(value, part)
+
+        if value == nil then
+            -- Another mod might be hooking the function,
+            -- we search all the upvalues inside this function and see if there's a match
+            if depth < MAX_UPVALUE_SEARCH_DEPTH then
+                for _, value in upvalue_iter(fn) do
+                    if type(value) == "function" then
+                        local value, scope_fn, index = ToolUtil.GetUpvalue(value, path, depth + 1)
+                        if value then
+                            return value, scope_fn, index
+                        end
+                    end
+                end
+            end
+            break
+        end
+    end
+
+    return value, scope_fn, index
 end
 
 ---@param fn function
 ---@param path string
 ---@param value any
-function ToolUtil.SetUpvalue(fn, value, path)
-    local _, i, source_fn = ToolUtil.GetUpvalue(fn, path)
-    debug.setupvalue(source_fn, i, value)
+function ToolUtil.SetUpvalue(fn, path, value)
+    local _, scope_fn, index = ToolUtil.GetUpvalue(fn, path)
+    debug.setupvalue(scope_fn, index, value)
 end
 
 ---@param t table

--- a/main/toolutil.lua
+++ b/main/toolutil.lua
@@ -55,7 +55,7 @@ local MAX_UPVALUE_SEARCH_DEPTH = 3
 --- ```
 ---@param fn function
 ---@param path string
----@return any, number, function
+---@return any, function, number
 function ToolUtil.GetUpvalue(fn, path, depth)
     if not depth then
         depth = 1

--- a/postinit/components/ambientlighting.lua
+++ b/postinit/components/ambientlighting.lua
@@ -42,7 +42,7 @@ AddComponentPostInit("ambientlighting", function(self, inst)
 
     local DoUpdateFlash = ToolUtil.GetUpvalue(self.OnUpdate, "DoUpdateFlash")
     local _overridecolour = ToolUtil.GetUpvalue(DoUpdateFlash, "_overridecolour")
-    local ComputeTargetColour = ToolUtil.GetUpvalue(DoUpdateFlash, "ComputeTargetColour")
+    local ComputeTargetColour, i = ToolUtil.GetUpvalue(DoUpdateFlash, "ComputeTargetColour")
 
     local function Pl_ComputeTargetColour(targetsettings, timeoverride, ...)
         if targetsettings == _overridecolour and ThePlayer and ThePlayer:HasTag("inside_interior") then
@@ -64,7 +64,7 @@ AddComponentPostInit("ambientlighting", function(self, inst)
         ComputeTargetColour(targetsettings, timeoverride, ...)
     end
 
-    ToolUtil.SetUpvalue(DoUpdateFlash, Pl_ComputeTargetColour, "ComputeTargetColour")
+    debug.setupvalue(DoUpdateFlash, i, Pl_ComputeTargetColour)
 
     function self:Pl_Refresh()
         Pl_ComputeTargetColour(_overridecolour, 0.1)

--- a/postinit/components/ambientlighting.lua
+++ b/postinit/components/ambientlighting.lua
@@ -42,7 +42,7 @@ AddComponentPostInit("ambientlighting", function(self, inst)
 
     local DoUpdateFlash = ToolUtil.GetUpvalue(self.OnUpdate, "DoUpdateFlash")
     local _overridecolour = ToolUtil.GetUpvalue(DoUpdateFlash, "_overridecolour")
-    local ComputeTargetColour, i = ToolUtil.GetUpvalue(DoUpdateFlash, "ComputeTargetColour")
+    local ComputeTargetColour, scope_fn, i = ToolUtil.GetUpvalue(DoUpdateFlash, "ComputeTargetColour")
 
     local function Pl_ComputeTargetColour(targetsettings, timeoverride, ...)
         if targetsettings == _overridecolour and ThePlayer and ThePlayer:HasTag("inside_interior") then
@@ -64,7 +64,7 @@ AddComponentPostInit("ambientlighting", function(self, inst)
         ComputeTargetColour(targetsettings, timeoverride, ...)
     end
 
-    debug.setupvalue(DoUpdateFlash, i, Pl_ComputeTargetColour)
+    debug.setupvalue(scope_fn, i, Pl_ComputeTargetColour)
 
     function self:Pl_Refresh()
         Pl_ComputeTargetColour(_overridecolour, 0.1)

--- a/postinit/components/kramped.lua
+++ b/postinit/components/kramped.lua
@@ -4,7 +4,7 @@ GLOBAL.setfenv(1, GLOBAL)
 AddComponentPostInit("kramped", function(self, inst)
     local OnPlayerJoined = inst:GetEventCallbacks("ms_playerjoined", TheWorld, "scripts/components/kramped.lua")
     local OnKilledOther = ToolUtil.GetUpvalue(OnPlayerJoined, "OnKilledOther")
-    local OnNaughtyAction, i = ToolUtil.GetUpvalue(OnKilledOther, "OnNaughtyAction")
+    local OnNaughtyAction, scope_fn, i = ToolUtil.GetUpvalue(OnKilledOther, "OnNaughtyAction")
 
     local New_OnNaughtyAction = function(how_naughty, playerdata, ...)
         if playerdata.player:GetIsInInterior() then
@@ -19,7 +19,7 @@ AddComponentPostInit("kramped", function(self, inst)
             OnNaughtyAction(how_naughty, playerdata, ...)
         end
     end
-    debug.setupvalue(OnKilledOther, i, New_OnNaughtyAction)
+    debug.setupvalue(scope_fn, i, New_OnNaughtyAction)
 
     local _activeplayers = ToolUtil.GetUpvalue(self.OnUpdate, "_activeplayers")
 

--- a/postinit/components/playercontroller.lua
+++ b/postinit/components/playercontroller.lua
@@ -17,7 +17,7 @@ local function get_tool_action(tool, target)
     end
 end
 
-local _GetPickupAction, i = ToolUtil.GetUpvalue(PlayerController.GetActionButtonAction, "GetPickupAction")
+local _GetPickupAction, scope_fn, i = ToolUtil.GetUpvalue(PlayerController.GetActionButtonAction, "GetPickupAction")
 local GetPickupAction = function(self, target, tool, ...)
     local action = _GetPickupAction(self, target, tool, ...)
     if not action then
@@ -42,7 +42,7 @@ local GetPickupAction = function(self, target, tool, ...)
     end
     return action
 end
-debug.setupvalue(PlayerController.GetActionButtonAction, i, GetPickupAction)
+debug.setupvalue(scope_fn, i, GetPickupAction)
 
 
 local _GetActionButtonAction = PlayerController.GetActionButtonAction

--- a/postinit/components/rider_replica.lua
+++ b/postinit/components/rider_replica.lua
@@ -2,7 +2,7 @@ GLOBAL.setfenv(1, GLOBAL)
 
 local Rider_Replica = require("components/rider_replica")
 
-local GetPickupAction, i, ActionButtonOverride = ToolUtil.GetUpvalue(Rider_Replica.SetActionFilter, "ActionButtonOverride.GetPickupAction")
+local GetPickupAction, ActionButtonOverride, i = ToolUtil.GetUpvalue(Rider_Replica.SetActionFilter, "ActionButtonOverride.GetPickupAction")
 if GetPickupAction then
     debug.setupvalue(ActionButtonOverride, i, function(self, target, tool, ...)
         if target:HasTag("smolder") then

--- a/postinit/components/rider_replica.lua
+++ b/postinit/components/rider_replica.lua
@@ -2,24 +2,25 @@ GLOBAL.setfenv(1, GLOBAL)
 
 local Rider_Replica = require("components/rider_replica")
 
-local _GetPickupAction = ToolUtil.GetUpvalue(Rider_Replica.SetActionFilter, "ActionButtonOverride.GetPickupAction")
-local GetPickupAction = function(self, target, tool, ...)
-    if target:HasTag("smolder") then
-        return ACTIONS.SMOTHER
-    elseif tool ~= nil then
-        for action, _ in pairs(TOOLACTIONS) do
-            if target:HasTag(action .. "_workable") then
-                if tool:HasTag(action .. "_tool") then
-                    return ACTIONS[action]
+local GetPickupAction, i, ActionButtonOverride = ToolUtil.GetUpvalue(Rider_Replica.SetActionFilter, "ActionButtonOverride.GetPickupAction")
+if GetPickupAction then
+    debug.setupvalue(ActionButtonOverride, i, function(self, target, tool, ...)
+        if target:HasTag("smolder") then
+            return ACTIONS.SMOTHER
+        elseif tool ~= nil then
+            for action, _ in pairs(TOOLACTIONS) do
+                if target:HasTag(action .. "_workable") then
+                    if tool:HasTag(action .. "_tool") then
+                        return ACTIONS[action]
+                    end
+                    -- break
                 end
-                -- break
             end
         end
-    end
 
-    return _GetPickupAction(self, target, tool, ...)
+        return GetPickupAction(self, target, tool, ...)
+    end)
 end
-ToolUtil.SetUpvalue(Rider_Replica.SetActionFilter, GetPickupAction, "ActionButtonOverride.GetPickupAction")
 
 function Rider_Replica:GetMountSpeedMultiplier()
     local multiplier = 1

--- a/postinit/components/sanity.lua
+++ b/postinit/components/sanity.lua
@@ -30,8 +30,8 @@ local function GetLightDrainState(inst)
     end
 end
 
-local _LIGHT_SANITY_DRAINS = ToolUtil.GetUpvalue(Sanity.Recalc, "LIGHT_SANITY_DRAINS")
-local LIGHT_SANITY_DRAINS_INSANITY = shallowcopy(_LIGHT_SANITY_DRAINS[SANITY_MODE_INSANITY])
+local LIGHT_SANITY_DRAINS = ToolUtil.GetUpvalue(Sanity.Recalc, "LIGHT_SANITY_DRAINS")
+local LIGHT_SANITY_DRAINS_INSANITY = shallowcopy(LIGHT_SANITY_DRAINS[SANITY_MODE_INSANITY])
 
 local SANITY_MODE_INSANITY_OVERRIDE = {
     [LIGHT_DRAIN_STATE.OUTSIDE] = LIGHT_SANITY_DRAINS_INSANITY,
@@ -61,19 +61,17 @@ local SANITY_MODE_INSANITY_OVERRIDE = {
 }
 
 function Sanity:UpdateInteriorMode()
-    local _LIGHT_SANITY_DRAINS, i = ToolUtil.GetUpvalue(self.Recalc, "LIGHT_SANITY_DRAINS")
     local drainstate = GetLightDrainState(self.inst)
-    _LIGHT_SANITY_DRAINS[SANITY_MODE_INSANITY] = SANITY_MODE_INSANITY_OVERRIDE[drainstate]
+    LIGHT_SANITY_DRAINS[SANITY_MODE_INSANITY] = SANITY_MODE_INSANITY_OVERRIDE[drainstate]
     if TheWorld.state.isday and not TheWorld:HasTag("cave") and drainstate == LIGHT_DRAIN_STATE.INTERIOR then
         local lightval = CanEntitySeeInDark(self.inst) and .9 or self.inst.LightWatcher:GetLightValue()
         local light_rate =
-            ((lightval > TUNING.SANITY_HIGH_LIGHT and _LIGHT_SANITY_DRAINS[SANITY_MODE_INSANITY].NIGHT_LIGHT) or
-            (lightval < TUNING.SANITY_LOW_LIGHT and _LIGHT_SANITY_DRAINS[SANITY_MODE_INSANITY].NIGHT_DARK) or
-            _LIGHT_SANITY_DRAINS[SANITY_MODE_INSANITY].NIGHT_DIM) * self.night_drain_mult
+            ((lightval > TUNING.SANITY_HIGH_LIGHT and LIGHT_SANITY_DRAINS[SANITY_MODE_INSANITY].NIGHT_LIGHT) or
+            (lightval < TUNING.SANITY_LOW_LIGHT and LIGHT_SANITY_DRAINS[SANITY_MODE_INSANITY].NIGHT_DARK) or
+            LIGHT_SANITY_DRAINS[SANITY_MODE_INSANITY].NIGHT_DIM) * self.night_drain_mult
 
-        _LIGHT_SANITY_DRAINS[SANITY_MODE_INSANITY].DAY = light_rate
+        LIGHT_SANITY_DRAINS[SANITY_MODE_INSANITY].DAY = light_rate
     end
-    debug.setupvalue(self.Recalc, i, _LIGHT_SANITY_DRAINS)
 end
 
 local _OnUpdate = Sanity.OnUpdate

--- a/postinit/prefabs/player.lua
+++ b/postinit/prefabs/player.lua
@@ -164,38 +164,6 @@ AddPlayerPostInit(function(inst)
         inst.components.hudindicatable:SetShouldTrackFunction(ShouldTrackfn)
     end
 
-    local _OnSetOwner = inst:GetEventCallbacks("setowner", inst, "scripts/prefabs/player_common.lua")
-    local _RegisterActivePlayerEventListeners = ToolUtil.GetUpvalue(_OnSetOwner, "RegisterActivePlayerEventListeners")
-
-    local function RegisterActivePlayerEventListeners(inst)
-        _RegisterActivePlayerEventListeners(inst)
-        if inst._PICKUPSOUNDS then
-            for k, v in pairs(inst._PICKUPSOUNDS) do
-                inst._PICKUPSOUNDS[k] = "dontstarve/HUD/collect_resource"
-            end
-        end
-    end
-
-    ToolUtil.SetUpvalue(_OnSetOwner, RegisterActivePlayerEventListeners, "RegisterActivePlayerEventListeners")
-
-    local _OnGotNewItem, i = ToolUtil.GetUpvalue(_RegisterActivePlayerEventListeners, "OnGotNewItem")
-
-    local function OnGotNewItem(inst, data, ...)
-        if TheWorld:HasTag("porkland") then
-            if data.slot ~= nil or data.eslot ~= nil or data.toactiveitem ~= nil then
-                if inst.replica.sailor and inst.replica.sailor:GetBoat() then
-                    TheFocalPoint.SoundEmitter:PlaySound("dontstarve_DLC002/common/HUD_water_collect_resource")
-                    return
-                end
-            end
-        end
-        return _OnGotNewItem(inst, data, ...)
-    end
-
-    if i then
-        debug.setupvalue(_RegisterActivePlayerEventListeners, i, OnGotNewItem)
-    end
-
     inst.components.lightwatcherproxy:UseHighPrecision()
 
     if not TheWorld.ismastersim then
@@ -234,3 +202,19 @@ AddPlayerPostInit(function(inst)
     end
 
 end)
+
+local MakePlayerCharacter = require("prefabs/player_common")
+local OnGotNewItem, i, RegisterActivePlayerEventListeners = ToolUtil.GetUpvalue(MakePlayerCharacter, "OnSetOwner.RegisterActivePlayerEventListeners.OnGotNewItem")
+if OnGotNewItem then
+    debug.setupvalue(RegisterActivePlayerEventListeners, i, function(inst, data, ...)
+        if TheWorld:HasTag("porkland") then
+            if data.slot ~= nil or data.eslot ~= nil or data.toactiveitem ~= nil then
+                if inst.replica.sailor and inst.replica.sailor:GetBoat() then
+                    TheFocalPoint.SoundEmitter:PlaySound("dontstarve_DLC002/common/HUD_water_collect_resource")
+                    return
+                end
+            end
+        end
+        return OnGotNewItem(inst, data, ...)
+    end)
+end

--- a/postinit/prefabs/player.lua
+++ b/postinit/prefabs/player.lua
@@ -204,7 +204,7 @@ AddPlayerPostInit(function(inst)
 end)
 
 local MakePlayerCharacter = require("prefabs/player_common")
-local OnGotNewItem, i, RegisterActivePlayerEventListeners = ToolUtil.GetUpvalue(MakePlayerCharacter, "OnSetOwner.RegisterActivePlayerEventListeners.OnGotNewItem")
+local OnGotNewItem, RegisterActivePlayerEventListeners, i = ToolUtil.GetUpvalue(MakePlayerCharacter, "OnSetOwner.RegisterActivePlayerEventListeners.OnGotNewItem")
 if OnGotNewItem then
     debug.setupvalue(RegisterActivePlayerEventListeners, i, function(inst, data, ...)
         if TheWorld:HasTag("porkland") then

--- a/postinit/prefabs/spoiledfood.lua
+++ b/postinit/prefabs/spoiledfood.lua
@@ -2,7 +2,7 @@ GLOBAL.setfenv(1, GLOBAL)
 
 AddPrefabRegisterPostInit(function(spoiled_food)
     local spoiled_food_constructor = spoiled_food.fn
-    local food_OnIsRaining, i, food_mastersim_init = ToolUtil.GetUpvalue(spoiled_food_constructor, "food_mastersim_init.food_OnIsRaining")
+    local food_OnIsRaining, food_mastersim_init, i = ToolUtil.GetUpvalue(spoiled_food_constructor, "food_mastersim_init.food_OnIsRaining")
     if not food_OnIsRaining then
         return
     end

--- a/postinit/prefabs/spoiledfood.lua
+++ b/postinit/prefabs/spoiledfood.lua
@@ -1,24 +1,16 @@
-local AddPrefabPostInit = AddPrefabPostInit
 GLOBAL.setfenv(1, GLOBAL)
 
-AddPrefabPostInit("spoiled_food", function(inst)
-    if not TheWorld.ismastersim then
-        return
-    end
-
-    local food_OnDropped = inst:GetEventCallbacks("ondropped", inst, "scripts/prefabs/spoiledfood.lua")
-    if not food_OnDropped then
-        return
-    end
-    local food_OnIsRaining, i = ToolUtil.GetUpvalue(food_OnDropped, "food_OnIsRaining")
+AddPrefabRegisterPostInit(function(spoiled_food)
+    local spoiled_food_constructor = spoiled_food.fn
+    local food_OnIsRaining, i, food_mastersim_init = ToolUtil.GetUpvalue(spoiled_food_constructor, "food_mastersim_init.food_OnIsRaining")
     if not food_OnIsRaining then
         return
     end
-    debug.setupvalue(food_OnDropped, i, function(inst, israining)
+    debug.setupvalue(food_mastersim_init, i, function(inst, israining, ...)
         if inst:GetIsInInterior() then
             inst.components.disappears:StopDisappear()
             return
         end
-        return food_OnIsRaining(inst, israining)
+        return food_OnIsRaining(inst, israining, ...)
     end)
 end)

--- a/postinit/prefabs/telestaff.lua
+++ b/postinit/prefabs/telestaff.lua
@@ -1,29 +1,18 @@
-local AddPrefabPostInit = AddPrefabPostInit
 GLOBAL.setfenv(1, GLOBAL)
 
-AddPrefabPostInit("telestaff", function(inst)
-    if not TheWorld.ismastersim then
-        return inst
-    end
-
-    -- print("AddPrefabPostInit telestaff")
-    local teleport_func = inst.components.spellcaster.spell
-    local _teleport_start, i = ToolUtil.GetUpvalue(teleport_func, "teleport_start")
-    if not _teleport_start then
+AddPrefabRegisterPostInit(function(telestaff)
+    local telestaff_constructor = telestaff.fn
+    local teleport_start, i, teleport_func = ToolUtil.GetUpvalue(telestaff_constructor, "teleport_func.teleport_start")
+    if not teleport_start then
         return
-        -- print("not _teleport_start")
     end
-
-    local function teleport_start(teleportee, staff, caster, loctarget, target_in_ocean, no_teleport, ...)
+    debug.setupvalue(teleport_func, i, function(teleportee, staff, caster, loctarget, target_in_ocean, no_teleport, ...)
         -- print("teleport_start")
         if teleportee:GetCurrentInteriorID() then
             -- print("in interior")
             staff.components.finiteuses:Use(1)
             return
         end
-
-        return _teleport_start(teleportee, staff, caster, loctarget, target_in_ocean, no_teleport, ...)
-    end
-
-    debug.setupvalue(teleport_func, i, teleport_start)
+        return teleport_start(teleportee, staff, caster, loctarget, target_in_ocean, no_teleport, ...)
+    end)
 end)

--- a/postinit/prefabs/telestaff.lua
+++ b/postinit/prefabs/telestaff.lua
@@ -2,7 +2,7 @@ GLOBAL.setfenv(1, GLOBAL)
 
 AddPrefabRegisterPostInit(function(telestaff)
     local telestaff_constructor = telestaff.fn
-    local teleport_start, i, teleport_func = ToolUtil.GetUpvalue(telestaff_constructor, "teleport_func.teleport_start")
+    local teleport_start, teleport_func, i = ToolUtil.GetUpvalue(telestaff_constructor, "teleport_func.teleport_start")
     if not teleport_start then
         return
     end

--- a/postinit/stategraphs/SGwilson.lua
+++ b/postinit/stategraphs/SGwilson.lua
@@ -2667,9 +2667,9 @@ AddStategraphPostInit("wilson", function(sg)
 
     local _attacked_eventhandler = sg.events.attacked.fn
 
-    local _DoHurtSound, DoHurtSound_i = ToolUtil.GetUpvalue(_attacked_eventhandler, "DoHurtSound")
+    local _DoHurtSound, scope_fn, DoHurtSound_i = ToolUtil.GetUpvalue(_attacked_eventhandler, "DoHurtSound")
     if DoHurtSound_i then
-        debug.setupvalue(_attacked_eventhandler, DoHurtSound_i,function(inst)
+        debug.setupvalue(scope_fn, DoHurtSound_i,function(inst)
             if inst:HasTag("ironlord") then
                 return
             end

--- a/postinit/widgets/inventorybar.lua
+++ b/postinit/widgets/inventorybar.lua
@@ -28,15 +28,12 @@ function InventoryBar:GetInventoryLists(same_container_only, ...)
     return lists
 end
 
-local _RebuildLayout = ToolUtil.GetUpvalue(InventoryBar.Rebuild, "RebuildLayout")
-local function RebuildLayout(self, inventory, overflow, do_integrated_backpack, ...)
+local RebuildLayout, i = ToolUtil.GetUpvalue(InventoryBar.Rebuild, "RebuildLayout")
+debug.setupvalue(InventoryBar.Rebuild, i, function(self, inventory, overflow, do_integrated_backpack, ...)
     local boatwidget = self.boatwidget
     if boatwidget then
         local x, _, z = boatwidget:GetPosition():Get()
         boatwidget:SetPosition(x, do_integrated_backpack and 115 or 75, z)
     end
-
-    _RebuildLayout(self, inventory, overflow, do_integrated_backpack, ...)
-end
-
-ToolUtil.SetUpvalue(InventoryBar.Rebuild, RebuildLayout, "RebuildLayout")
+    return RebuildLayout(self, inventory, overflow, do_integrated_backpack, ...)
+end)

--- a/postinit/widgets/inventorybar.lua
+++ b/postinit/widgets/inventorybar.lua
@@ -28,8 +28,8 @@ function InventoryBar:GetInventoryLists(same_container_only, ...)
     return lists
 end
 
-local RebuildLayout, i = ToolUtil.GetUpvalue(InventoryBar.Rebuild, "RebuildLayout")
-debug.setupvalue(InventoryBar.Rebuild, i, function(self, inventory, overflow, do_integrated_backpack, ...)
+local RebuildLayout, scope_fn, i = ToolUtil.GetUpvalue(InventoryBar.Rebuild, "RebuildLayout")
+debug.setupvalue(scope_fn, i, function(self, inventory, overflow, do_integrated_backpack, ...)
     local boatwidget = self.boatwidget
     if boatwidget then
         local x, _, z = boatwidget:GetPosition():Get()


### PR DESCRIPTION
Fix #824
Fix #846

`ToolUtil.GetUpvalue` will now search recursively through all the upvalues for up to 3 levels, this helps for situations like another hooking a function before us
And `ToolUtil.GetUpvalue` now returns `value, scope_fn, index` instead `value, index, scope_fn`, this is to align with the new expectation of using it through `debug.setupvalue(scope_fn, index, new_value)`

Also changed some of the other implementations to use `debug.setupvalue` directly instead of using `ToolUtil.SetUpvalue` as much possible since they already have the scope function and up index found

Another improvement is getting rid of some upvalue hacks on every new instance spawn, this is done by introducing a new function `AddPrefabRegisterPostInit` to hook the values outside of the constructors