### PR TITLE
fix the clock

### DIFF
--- a/postinit/components/clock.lua
+++ b/postinit/components/clock.lua
@@ -638,19 +638,19 @@ local function MakeClock(self, clocktype)
         local _OnLoad = self.OnLoad
         function self:OnLoad(data, ...)
             if not data["cycles" .. clocktype] and data.cycles then
-                inst:DoTaskInTime(0, function()
-                    local segs = NUM_SEGS * data.cycles
-                    local phasenum = PHASES[data.phase] - 1
-                    while phasenum > 0 do
-                        if PHASE_NAMES[phasenum] then
-                            segs = segs + data.segs[PHASE_NAMES[phasenum]]
-                        end
-                        phasenum = phasenum - 1
-                    end
-                    OnUpdate(self, (TUNING.SEG_TIME * segs) + data.remainingtimeinphase)
-                    self["Dump_" .. clocktype]()
-                    print('"Retrofit" complete')
-                end)
+                -- inst:DoTaskInTime(0, function()
+                --     local segs = NUM_SEGS * data.cycles
+                --     local phasenum = PHASES[data.phase] - 1
+                --     while phasenum > 0 do
+                --         if PHASE_NAMES[phasenum] then
+                --             segs = segs + data.segs[PHASE_NAMES[phasenum]]
+                --         end
+                --         phasenum = phasenum - 1
+                --     end
+                --     OnUpdate(self, (TUNING.SEG_TIME * segs) + data.remainingtimeinphase)
+                --     self["Dump_" .. clocktype]()
+                --     print('"Retrofit" complete')
+                -- end)
             else
                 local totalsegs = 0
                 for i, v in ipairs(_segs) do


### PR DESCRIPTION
修复一个bug，该bug导致向旧存档中添加云霄国度mod时，猪镇时钟被向前推动相当与当前天数的时间长度，最终导致猪镇时钟为默认时钟的两倍（l例如：向一个运行了50天的森林世界加入云霄国度mod，导致该世界的猪镇时钟数据错误地变成100天）