### PR TITLE
增加森林和洞穴预设

### DIFF
--- a/modservercreationmain.lua
+++ b/modservercreationmain.lua
@@ -12,7 +12,8 @@ local PopupDialogScreen = require("screens/redux/popupdialog")
 local ChooseWorldSreen = require("widgets/redux/chooseworldscreen")
 
 local world_locations = {
-    [1] = {PORKLAND = true},
+    [1] = {FOREST = true, PORKLAND = true},
+    [2] = {CAVE = true},
 }
 
 local DEV = not modname:find("workshop-")


### PR DESCRIPTION
为了玩双穿时，能够直接生成森林/洞穴世界
洞穴预设丢失会导致玩家在洞穴点选择世界时导致游戏崩溃