### PR TITLE
洒水器水管接口坐标需要定位到视觉上的水域上

### DIFF
--- a/scripts/prefabs/sprinkler.lua
+++ b/scripts/prefabs/sprinkler.lua
@@ -397,6 +397,7 @@ local function fn()
     inst.OnLoadPostPass = OnLoadPostPass
     inst.OnEntitySleep = OnEntitySleep
     inst.UpdateSpray = UpdateSpray
+    inst.CreatePipes = CreatePipes
 
     inst.moisturizing = 2
     inst.water_spray = nil
@@ -406,7 +407,7 @@ local function fn()
 
     inst:DoTaskInTime(0.1, function()
         if not inst.pipes or #inst.pipes < 1 then
-            CreatePipes(inst)
+            inst:CreatePipes()
         end
         ExtendPipes(inst)
     end)


### PR DESCRIPTION
在森林世界时它会接在tile边缘上，但是因为森林的陆地边缘侵入水域导致看起来在陆地上